### PR TITLE
feat: use gpt-4o instead of gpt4-vision-preview; Remove saving of config file: Local .env is sufficient.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ https://github.com/askui/intent-pilot/assets/106730702/582d7dec-e3ff-43fd-9ab7-0
 
 ### Setup
 
-- Python 3.9 or later
+- Python 3.11 or later
 - OpenAI Key
 - AskUI credentials
     - `ASKUI_WORKSPACE_ID` and `ASKUI_TOKEN` are needed in `.env` file to get the product running.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ https://github.com/askui/intent-pilot/assets/106730702/582d7dec-e3ff-43fd-9ab7-0
     - You can get your own AskUI credentials by signing up at [AskUI](https://askui.com)
 - You can also copy the `.env.example` file to `.env` and fill in the required details OR You can enter the credentials in the terminal when you start the app.
 
+**⚠️IMPORTANT: If you saved the credentials with the flag `-c --config`, you MUST delete them with the flag `-d --deleteconfig` again for the local `.env` file to be read again.**
+
 #### Linux
 
 - In case of linux, you may need to install the following packages:
@@ -103,6 +105,10 @@ pdm run intent
 
 * `--debug`: Prints debug output to the console
 * `--model -m <modelname>`: The model to use - `llava` or default `gpt4v`
+* `-c --config`: Prompts to save the credentials configuration to `~/.askui/intent-pilot.env`
+* `-d --deleteconfig`: Prompts to delete the credentials from `~/.askui/intent-pilot.env`
+
+
 
 ## Use Local llava Model Instead of gpt4-Vision
 Install [Ollama for your system from their Website](https://ollama.com/).

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ https://github.com/askui/intent-pilot/assets/106730702/582d7dec-e3ff-43fd-9ab7-0
 
 - Python 3.9 or later
 - OpenAI Key
-- AskUI token
+- AskUI credentials
     - `ASKUI_WORKSPACE_ID` and `ASKUI_TOKEN` are needed in `.env` file to get the product running.
     - You can get your own AskUI credentials by signing up at [AskUI](https://askui.com)
 - You can also copy the `.env.example` file to `.env` and fill in the required details OR You can enter the credentials in the terminal when you start the app.
@@ -119,8 +119,6 @@ For real-time discussions and community support, join our Discord server:
 ## Contributing
 
 Thank you for your interest in contributing! We welcome involvement from the community.
-
-We are still deciding on the contribution guidelines. Please stay tuned for updates.
 
 ## Roadmap
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "fuzzywuzzy[speedup]>=0.18.0",
     "pyperclip>=1.8.2",
     "langchain>=0.1.13",
+    "langchain-community>=0.2.16",
 ]
 requires-python = ">=3.9"
 readme = "README.md"

--- a/src/intent_pilot/run/app.py
+++ b/src/intent_pilot/run/app.py
@@ -23,6 +23,8 @@ def get_args():
     parser = argparse.ArgumentParser(description="Intent-Pilot")
     parser.add_argument("--debug", action="store_true", help="Enable verbose mode")
     parser.add_argument('-m', '--model', type=str, default="gpt4v", help='Enter a model: llava or gpt4v (default: gpt4v)')
+    parser.add_argument('-c', '--config', action="store_true", help='Display prompt for saving user config in ~/.askui/intent-pilot.env')
+    parser.add_argument('-d', '--deleteconfig', action="store_true", help='Deletes the configuration from file ~/.askui/intent-pilot.env')
 
     args = parser.parse_args()
     return args
@@ -49,6 +51,18 @@ def main():
         print(f"{ANSI_BLUE} [Intent Pilot] Using model {Models.LLAVA}")
     else:
         raise ValueError(f"We do not support this model: {config.model}")
+
+    if (
+        args.deleteconfig
+        and prompt("Do you want to delete the user config? y/n: \n") == "y"
+    ):
+        config.delete_config()
+
+    if (
+        args.config
+        and prompt("Do you want to save the user config? y/n: \n") == "y"
+    ):
+        config.save_config()
 
     objective = get_user_input()
     messages = []

--- a/src/intent_pilot/run/app.py
+++ b/src/intent_pilot/run/app.py
@@ -38,12 +38,6 @@ def main():
 
     config.initialize_askui()
 
-    if (
-        not config.is_user_config_exists()
-        and prompt("Do you want to save the config user? y/n: \n") == "y"
-    ):
-        config.save_config()
-
     config.model = args.model
 
     client = None

--- a/src/intent_pilot/utils/config.py
+++ b/src/intent_pilot/utils/config.py
@@ -36,11 +36,6 @@ class Config:
         self.openai_temperature = 0.1
         self.openai_max_tokens = 1000
 
-        self.user_config_dir = pathlib.Path.home() / pathlib.Path(".askui")
-        self.user_config_env_path = self.user_config_dir / "intent-pilot.env"
-
-        # load from user config file
-        load_dotenv(self.user_config_env_path)
         # load from local .env file
         load_dotenv()
 
@@ -50,9 +45,6 @@ class Config:
             value_dict = get_env_values([env_name])
             value = value_dict[env_name]
         return value
-
-    def is_user_config_exists(self) -> bool:
-        return os.path.exists(self.user_config_env_path)
 
     def initialize_askui(self):
         self.aui_workspace_id = self.__read_from_env_or_ask("ASKUI_WORKSPACE_ID")
@@ -87,11 +79,3 @@ class Config:
     def initialize_ollama(self, model="llava", temperature=0):
         client = ChatOllama(model=model, temperature=temperature)
         return client
-
-    def save_config(self):
-        os.makedirs(self.user_config_dir, exist_ok=True)
-        with open(self.user_config_env_path, "w") as f:
-            f.write(f"ASKUI_WORKSPACE_ID={self.aui_workspace_id}\n")
-            f.write(f"ASKUI_TOKEN={self.aui_token}\n")
-            f.write(f"OPENAI_API_KEY={self.openai_api_key}\n")
-            f.write(f"OPENAI_API_BASE_URL={self.openai_base_url}\n")

--- a/src/intent_pilot/utils/config.py
+++ b/src/intent_pilot/utils/config.py
@@ -58,8 +58,6 @@ class Config:
     def initialize_askui(self):
         self.aui_workspace_id = self.__read_from_env_or_ask("ASKUI_WORKSPACE_ID")
         self.aui_token = self.__read_from_env_or_ask("ASKUI_TOKEN")
-        print(self.aui_workspace_id)
-        print(self.aui_token)
 
     def assert_env_var(self, env_var):
         """

--- a/src/intent_pilot/utils/config.py
+++ b/src/intent_pilot/utils/config.py
@@ -36,6 +36,12 @@ class Config:
         self.openai_temperature = 0.1
         self.openai_max_tokens = 1000
 
+        self.user_config_dir = pathlib.Path.home() / pathlib.Path(".askui")
+        self.user_config_env_path = self.user_config_dir / "intent-pilot.env"
+
+        # load from user config file
+        load_dotenv(self.user_config_env_path)
+
         # load from local .env file
         load_dotenv()
 
@@ -46,9 +52,14 @@ class Config:
             value = value_dict[env_name]
         return value
 
+    def is_user_config_exists(self) -> bool:
+        return os.path.exists(self.user_config_env_path)
+
     def initialize_askui(self):
         self.aui_workspace_id = self.__read_from_env_or_ask("ASKUI_WORKSPACE_ID")
         self.aui_token = self.__read_from_env_or_ask("ASKUI_TOKEN")
+        print(self.aui_workspace_id)
+        print(self.aui_token)
 
     def assert_env_var(self, env_var):
         """
@@ -79,3 +90,17 @@ class Config:
     def initialize_ollama(self, model="llava", temperature=0):
         client = ChatOllama(model=model, temperature=temperature)
         return client
+
+    def save_config(self):
+        os.makedirs(self.user_config_dir, exist_ok=True)
+        with open(self.user_config_env_path, "w") as f:
+            f.write(f"ASKUI_WORKSPACE_ID={self.aui_workspace_id}\n")
+            f.write(f"ASKUI_TOKEN={self.aui_token}\n")
+            f.write(f"OPENAI_API_KEY={self.openai_api_key}\n")
+            f.write(f"OPENAI_API_BASE_URL={self.openai_base_url}\n")
+
+    def delete_config(self):
+        try:
+            os.remove(self.user_config_env_path)
+        except OSError:
+            pass

--- a/src/intent_pilot/utils/models/gpt4.py
+++ b/src/intent_pilot/utils/models/gpt4.py
@@ -13,7 +13,7 @@ def format_gpt4v_message(user_prompt, img_base64_labeled):
 
 def get_response_from_gpt4v(openai_client, messages, temperature=0.7, max_tokens=1000):
     response = openai_client.chat.completions.create(
-        model="gpt-4-vision-preview",
+        model="gpt-4o",
         messages=messages,
         presence_penalty=1,
         frequency_penalty=1,


### PR DESCRIPTION
* Migrated from gpt4-vision-preview to gpt-4o: Cheaper, faster, and not deprecated.
* Removed the saving of the config option to `~/.askui/intent-pilot.env` as it can lead to resident config as there is no option to overwrite the config. Also, we already have a `.env` that works just fine 😉 .